### PR TITLE
Option to Suppress Default Currency

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -23,7 +23,7 @@ exports.wrapRootElement = function (_ref, pluginOptions) {
     version: '3.0.15',
     locales: {},
     defaultLang: 'en'
-  }, {}, pluginOptions);
+  }, pluginOptions);
 
   return /*#__PURE__*/React.createElement(SnipcartProvider, _options, element);
 };

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -29,7 +29,7 @@ exports.onRenderBody = function (_ref, pluginOptions) {
     version: "3.0.15",
     innerHTML: "",
     openCartOnAdd: true
-  }, {}, pluginOptions); // find public api key in options plugin or environment variable
+  }, pluginOptions); // find public api key in options plugin or environment variable
 
 
   var publicApiKey = GATSBY_SNIPCART_API_KEY || _options.publicApiKey;
@@ -37,13 +37,17 @@ exports.onRenderBody = function (_ref, pluginOptions) {
   if (!publicApiKey) {
     throw new Error("Snipcart public API Key is not defined. Insert in plugin options the \"publicApiKey\" parameter or use GATSBY_SNIPCART_API_KEY in environment variable");
     return null;
-  }
+  } // Use a default currency value by default. True if plugin option is undefined
+  // or defined as true. False only if plugin option is defined as false.
 
+
+  var provideDefaultCurrency = _options.provideDefaultCurrency !== false ? true : false;
   var components = [/*#__PURE__*/React.createElement(Snipcart, {
     key: "snipcart",
     publicApiKey: publicApiKey,
-    innerHTML: _options.innerHTML,
-    currency: _options.currency,
+    innerHTML: _options.innerHTML // Only pass currency value if using default currency
+    ,
+    currency: provideDefaultCurrency ? _options.currency : null,
     openCartOnAdd: _options.openCartOnAdd
   }),
   /*#__PURE__*/
@@ -79,7 +83,7 @@ exports.wrapRootElement = function (_ref2, pluginOptions) {
     version: "3.0.15",
     locales: {},
     defaultLang: "en"
-  }, {}, pluginOptions);
+  }, pluginOptions);
 
   return /*#__PURE__*/React.createElement(SnipcartProvider, _options, element);
 };

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,7 @@ Read the snipcart document [https://docs.snipcart.com/v3](https://docs.snipcart.
 - version : define version of snipcart library
 - publicApiKey: Snipcart public api key
 - defaultLang : define default language
+- provideDefaultCurrency: Facilitates multi-currency carts. Set to false to prevent a default currency from being specified, resetting the currency on an active cart session
 - currency : define currency
 - openCartOnAdd : define if the "snipcart" library opens the cart when user clicks on "add to cart" button
 - locales : object of locales string. First level of keys is lang key. Example: {fr: {...}}

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -28,12 +28,17 @@ exports.onRenderBody = ({ setPostBodyComponents }, pluginOptions = {}) => {
     return null;
   }
 
+  // Use a default currency value by default. True if plugin option is undefined
+  // or defined as true. False only if plugin option is defined as false.
+  const provideDefaultCurrency = (_options.provideDefaultCurrency !== false) ? true : false
+
   const components = [
     <Snipcart
       key="snipcart"
       publicApiKey={publicApiKey}
       innerHTML={_options.innerHTML}
-      currency={_options.currency}
+      // Only pass currency value if using default currency
+      currency={provideDefaultCurrency ? _options.currency : null}
       openCartOnAdd={_options.openCartOnAdd}
     />,
     // insert style

--- a/store/index.js
+++ b/store/index.js
@@ -24,27 +24,27 @@ exports.SnipcartContext = SnipcartContext;
 var reducer = function reducer(state, action) {
   switch (state, action.type) {
     case "setReady":
-      return (0, _extends2.default)({}, state, {}, {
+      return (0, _extends2.default)({}, state, {
         ready: action.payload
       });
 
     case "setQuantity":
-      return (0, _extends2.default)({}, state, {}, {
+      return (0, _extends2.default)({}, state, {
         cartQuantity: action.payload
       });
 
     case "setUserStatus":
-      return (0, _extends2.default)({}, state, {}, {
+      return (0, _extends2.default)({}, state, {
         userStatus: action.payload
       });
 
     case "setTotal":
-      return (0, _extends2.default)({}, state, {}, {
+      return (0, _extends2.default)({}, state, {
         cartTotal: action.payload
       });
 
     case "setSubTotal":
-      return (0, _extends2.default)({}, state, {}, {
+      return (0, _extends2.default)({}, state, {
         cartSubTotal: action.payload
       });
 


### PR DESCRIPTION
Setting a `data-currency` attribute on the `div#snipcart` div causes the currency on the Snipcart cart to be reset. When using Snipcart in a multi-currency environment, this can mean clearing a user’s active cart session. 

If the default currency is set to USD, but while using the shop a visitor sets the currency for their cart session to EUR, it will stay in EUR as they browse. However, if they reload or leave and come back, the default currency value of USD will be re-applied and the contents of the cart will be cleared.

This update allows for this plugin to be used without a default currency, so that an active Snipcart session with a currency different from the default currency will not be cleared.