### PR TITLE
Update Snipcart to 3.2.0

### DIFF
--- a/components/SnipcartProvider.js
+++ b/components/SnipcartProvider.js
@@ -56,7 +56,7 @@ var SnipcartProvider = function SnipcartProvider(props) {
 };
 
 SnipcartProvider.defaultProps = {
-  version: '3.0.15',
+  version: '3.2.0',
   locales: {},
   defaultLang: 'en'
 };

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -20,7 +20,7 @@ exports.wrapRootElement = function (_ref, pluginOptions) {
   }
 
   var _options = (0, _extends2.default)({}, {
-    version: "3.0.29",
+    version: "3.2.0",
     locales: {},
     defaultLang: "en"
   }, pluginOptions);

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -26,7 +26,7 @@ exports.onRenderBody = function (_ref, pluginOptions) {
   }
 
   var _options = (0, _extends2.default)({}, {
-    version: "3.0.29",
+    version: "3.2.0",
     innerHTML: "",
     openCartOnAdd: true,
     useSideCart: false,
@@ -84,7 +84,7 @@ exports.wrapRootElement = function (_ref2, pluginOptions) {
   }
 
   var _options = (0, _extends2.default)({}, {
-    version: "3.0.29",
+    version: "3.2.0",
     locales: {},
     defaultLang: "en"
   }, pluginOptions);

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-snipcart-advanced`,
       options: {
-        version: "3.0.29",
+        version: "3.2.0",
         publicApiKey: "#####", // use public api key here or in environment variable
         defaultLang: "fr",
         currency: "eur",
@@ -81,7 +81,7 @@ Read the snipcart document [https://docs.snipcart.com/v3](https://docs.snipcart.
 
 Default values :
 
-- version : 3.0.29
+- version : 3.2.0
 - defaultLang : "en"
 - currency : "usd"
 - openCartOnAdd : true

--- a/src/components/SnipcartProvider.js
+++ b/src/components/SnipcartProvider.js
@@ -35,7 +35,7 @@ const SnipcartProvider = props => {
 };
 
 SnipcartProvider.defaultProps = {
-  version: '3.0.15',
+  version: '3.2.0',
   locales: {},
   defaultLang: 'en',
 };

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -7,7 +7,7 @@ const SnipcartProvider = require("./components/SnipcartProvider").default;
 exports.wrapRootElement = ({ element }, pluginOptions = {}) => {
   const _options = {
     ...{
-      version: "3.0.29",
+      version: "3.2.0",
       locales: {},
       defaultLang: "en",
     },

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -12,7 +12,7 @@ const GATSBY_SNIPCART_API_KEY = process.env.GATSBY_SNIPCART_API_KEY;
 exports.onRenderBody = ({ setPostBodyComponents }, pluginOptions = {}) => {
   const _options = {
     ...{
-      version: "3.0.29",
+      version: "3.2.0",
       innerHTML: "",
       openCartOnAdd: true,
       useSideCart: false,
@@ -67,7 +67,7 @@ exports.onRenderBody = ({ setPostBodyComponents }, pluginOptions = {}) => {
 exports.wrapRootElement = ({ element }, pluginOptions = {}) => {
   const _options = {
     ...{
-      version: "3.0.29",
+      version: "3.2.0",
       locales: {},
       defaultLang: "en",
     },


### PR DESCRIPTION
This PR updates Snipcart's version to 3.2.0.