### PR TITLE
Edit locales issue

### DIFF
--- a/src/components/SnipcartProvider.js
+++ b/src/components/SnipcartProvider.js
@@ -8,7 +8,7 @@ const SnipcartProvider = props => {
   const [state, dispatch] = useStore();
   const {defaultLang, locales} = props;
   const changeLanguage = lang => {
-    const lng = locales[defaultLang] || {};
+    const lng = locales[lang] || {};
     window.Snipcart.api.session.setLanguage(lang, lng);
   };
   React.useEffect(() => {


### PR DESCRIPTION
When adding/editing locale from gatsby config and use that locale inside snipcart via $localize function, it always show english locale (default locale).
Fix it by getting the locale with the lang argument instead of using always the default locale.